### PR TITLE
Encoding issue

### DIFF
--- a/org.sbgn/src/org/sbgn/ConvertMilestone1to2.java
+++ b/org.sbgn/src/org/sbgn/ConvertMilestone1to2.java
@@ -1,7 +1,7 @@
 package org.sbgn;
 
 import java.io.File;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
@@ -41,7 +41,9 @@ public class ConvertMilestone1to2
 
 		// done, store result.
 		XMLOutputter xo = new XMLOutputter();
-		xo.output(doc, new FileWriter(out));
+		FileOutputStream outputStream = new FileOutputStream(out);
+		xo.output(doc, outputStream);
+		outputStream.close();
 	}
 
 	Set<String> existingIds = new HashSet<String>();

--- a/org.sbgn/src/org/sbgn/ConvertMilestone2to3.java
+++ b/org.sbgn/src/org/sbgn/ConvertMilestone2to3.java
@@ -1,7 +1,7 @@
 package org.sbgn;
 
 import java.io.File;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
 import java.io.IOException;
 
 import org.jdom.Document;
@@ -31,7 +31,9 @@ public class ConvertMilestone2to3
 
 		// done, store result.
 		XMLOutputter xo = new XMLOutputter();
-		xo.output(doc, new FileWriter(out));
+		FileOutputStream outputStream = new FileOutputStream(out);
+		xo.output(doc, outputStream);
+		outputStream.close();
 	}
 
 	/**

--- a/org.sbgn/test/org/sbgn/SbgnUtilTest.java
+++ b/org.sbgn/test/org/sbgn/SbgnUtilTest.java
@@ -1,0 +1,52 @@
+package org.sbgn;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+import javax.xml.bind.JAXBException;
+
+import org.junit.Test;
+import org.sbgn.bindings.Sbgn;
+
+public class SbgnUtilTest {
+
+  @Test
+  public void testUtfEncodingWithDifferentSystemFileEncoding() throws JAXBException {
+    try {
+      // modify the encoding that was taken from file.encoding system property
+      // this is done at JVM startup therefore instead of changing system property we
+      // must modify the cached value to simulate running it on the machine with
+      // ISO-8859-1 encoding
+      Field field = null;
+      for (Field f : Charset.class.getDeclaredFields()) {
+        if (f.getName().equals("defaultCharset")) {
+          field = f;
+        }
+      }
+      field.setAccessible(true);
+      Field modifiersField = Field.class.getDeclaredField("modifiers");
+      modifiersField.setAccessible(true);
+      modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+
+      field.set(null, StandardCharsets.ISO_8859_1);
+
+      try {
+        Sbgn sbgn = SbgnUtil.readFromFile(new File("test-files/PD/utf8_sbgn.0.2.sbgn"));
+        assertEquals("β", sbgn.getMap().get(0).getGlyph().get(0).getLabel().getText());
+      } finally {
+        //restore default encoding to UTF-8
+        field.set(null, StandardCharsets.UTF_8);
+      }
+
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -88,11 +88,13 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>${junit.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>ant</groupId>
       <artifactId>ant-junit</artifactId>
       <version>${ant.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>javax.xml.bind</groupId>

--- a/test-files/PD/utf8_sbgn.0.2.sbgn
+++ b/test-files/PD/utf8_sbgn.0.2.sbgn
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<sbgn xmlns="http://sbgn.org/libsbgn/0.2">
+    <map language="process description">
+        <glyph class="simple chemical" id="glyph_n3">
+            <label text="β"/>
+            <bbox w="140.0" h="32.0" x="75.0" y="272.53503"/>
+        </glyph>
+    </map>
+</sbgn>


### PR DESCRIPTION
This pull request solves the problem of reading sbgn 0.2/0.1 on operating systems that have defined files encoding different than encoding of xml file. This can happen for instance on windows machine with default ISO-8859-1 encoding and typical xml file encoded using UTF-8.

There is also a test unit that shows what happens in such situation.