### PR TITLE
Added 1 missing validation rule (layout)

### DIFF
--- a/validation/error-test-files/AF/af10115-fail.sbgn
+++ b/validation/error-test-files/AF/af10115-fail.sbgn
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<sbgn xmlns="http://sbgn.org/libsbgn/0.3">
+    <map id="map1" language="activity flow">
+        <glyph id="glyph7" class="biological activity">
+            <label text="A"/>
+            <bbox y="30.0" x="26.0" h="60.0" w="108.0"/>
+        </glyph>
+        <glyph id="glyph2" class="biological activity">
+            <label text="A"/>
+            <bbox y="30.0" x="26.0" h="60.0" w="108.0"/>
+        </glyph>
+        <glyph id="glyph3" class="biological activity">
+            <label text="B"/>
+            <bbox y="20.0" x="286.0" h="60.0" w="108.0"/>
+        </glyph>
+        <glyph id="glyph4" class="not">
+            <bbox y="89.0" x="179.0" h="42.0" w="42.0"/>
+            <port y="110.0" x="158.0" id="glyph4.1"/>
+            <port y="110.0" x="242.0" id="glyph4.2"/>
+        </glyph>
+        <arc target="glyph4.1" source="glyph2" id="arc0" class="logic arc">
+            <start y="90.0" x="126.8"/>
+            <end y="110.0" x="158.0"/>
+        </arc>
+        <arc target="glyph3" source="glyph4.2" id="arc2" class="positive influence">
+            <start y="110.0" x="242.0"/>
+            <end y="73.14286" x="286.0"/>
+        </arc>
+    </map>
+</sbgn>

--- a/validation/error-test-files/AF/af10115-fail.sbgn
+++ b/validation/error-test-files/AF/af10115-fail.sbgn
@@ -1,30 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <sbgn xmlns="http://sbgn.org/libsbgn/0.3">
     <map id="map1" language="activity flow">
-        <glyph id="glyph7" class="biological activity">
+        <glyph id="glyph1" class="biological activity">
             <label text="A"/>
-            <bbox y="30.0" x="26.0" h="60.0" w="108.0"/>
+            <bbox x="26.0" y="30.0" w="108.0" h="60.0"/>
         </glyph>
         <glyph id="glyph2" class="biological activity">
-            <label text="A"/>
-            <bbox y="30.0" x="26.0" h="60.0" w="108.0"/>
-        </glyph>
-        <glyph id="glyph3" class="biological activity">
             <label text="B"/>
-            <bbox y="20.0" x="286.0" h="60.0" w="108.0"/>
+            <bbox x="80.0" y="30.0" w="108.0" h="60.0"/>
         </glyph>
-        <glyph id="glyph4" class="not">
-            <bbox y="89.0" x="179.0" h="42.0" w="42.0"/>
-            <port y="110.0" x="158.0" id="glyph4.1"/>
-            <port y="110.0" x="242.0" id="glyph4.2"/>
-        </glyph>
-        <arc target="glyph4.1" source="glyph2" id="arc0" class="logic arc">
-            <start y="90.0" x="126.8"/>
-            <end y="110.0" x="158.0"/>
-        </arc>
-        <arc target="glyph3" source="glyph4.2" id="arc2" class="positive influence">
-            <start y="110.0" x="242.0"/>
-            <end y="73.14286" x="286.0"/>
-        </arc>
     </map>
 </sbgn>

--- a/validation/error-test-files/AF/af10115-pass.sbgn
+++ b/validation/error-test-files/AF/af10115-pass.sbgn
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<sbgn xmlns="http://sbgn.org/libsbgn/0.3">
+    <map id="map1" language="activity flow">
+        <glyph id="glyph2" class="biological activity">
+            <label text="A"/>
+            <bbox y="30.0" x="26.0" h="60.0" w="108.0"/>
+        </glyph>
+        <glyph id="glyph3" class="biological activity">
+            <label text="B"/>
+            <bbox y="20.0" x="286.0" h="60.0" w="108.0"/>
+        </glyph>
+        <glyph id="glyph4" class="not">
+            <bbox y="89.0" x="179.0" h="42.0" w="42.0"/>
+            <port y="110.0" x="158.0" id="glyph4.1"/>
+            <port y="110.0" x="242.0" id="glyph4.2"/>
+        </glyph>
+        <arc target="glyph4.1" source="glyph2" id="arc0" class="logic arc">
+            <start y="90.0" x="126.8"/>
+            <end y="110.0" x="158.0"/>
+        </arc>
+        <arc target="glyph3" source="glyph4.2" id="arc2" class="positive influence">
+            <start y="110.0" x="242.0"/>
+            <end y="73.14286" x="286.0"/>
+        </arc>
+    </map>
+</sbgn>

--- a/validation/rules/sbgn_af.sch
+++ b/validation/rules/sbgn_af.sch
@@ -34,6 +34,10 @@ Schematron validation for SBGN AF
 		<iso:active pattern="af10114"/>
 	</iso:phase>
 
+	<iso:phase id="layout">
+		<iso:active pattern="af10115"/>
+	</iso:phase>
+
 	<iso:pattern id="00000">
 		<iso:rule context="/*">
 			<iso:assert id="00000" name="sanity-check" test="false()">This assertion should always fail.</iso:assert>
@@ -94,7 +98,7 @@ Schematron validation for SBGN AF
 				id="af10102"
 				name="check-positive-influence-target-class"
 				role="error"
-				see="sbgn-af-L1V1.0-3.3.1"				
+				see="sbgn-af-L1V1.2-4.2.1.1"				
 				test="
 				$target-class='biological activity' or 
 				$target-class='phenotype'" 
@@ -256,6 +260,43 @@ Schematron validation for SBGN AF
 				test="
 				(($compartment-count = 0) and not (@compartmentRef)) or (($compartment-count &gt; 0) and @compartmentRef)"
 				diagnostics="id">If there are compartments defined, top-level glyphs must have a compartmentRef"
+			</iso:assert>
+		</iso:rule> 
+	</iso:pattern> 
+	 
+	<iso:pattern id="af10115">
+		<iso:rule context="sbgn:map/sbgn:glyph[
+			@class= 'biological activity' or 
+		@class = 'phenotype' or 
+		@class = 'submap' or 
+		@class = 'and' or 
+		@class = 'or' or 
+		@class = 'not' or 
+		@class = 'delay'
+		]">
+			<iso:let name="id" value="@id"/>
+			<iso:assert
+				id="af10115"
+				name="check-overlapping-nodes"
+				role="error"
+				test="not(following::sbgn:glyph[
+					(@class= 'biological activity' or
+				@class = 'phenotype' or
+				@class = 'submap' or
+				@class = 'and' or
+				@class = 'or' or
+				@class = 'not' or
+				@class = 'delay')
+				and @class != 'unit of information'
+				and (
+						(@x <= current()/@x + current()/@width)
+					and (@x + @width >= current()/@x)
+					and (@y <= current()/@y + current()/@height)
+					and (@y + @height >= current()/@y)
+					)
+				]
+				)"
+				diagnostics="id">Illegal overlapping nodes are not allowed in SBGN AF.
 			</iso:assert>
 		</iso:rule> 
 	</iso:pattern> 

--- a/validation/rules/sbgn_af.sch
+++ b/validation/rules/sbgn_af.sch
@@ -32,11 +32,10 @@ Schematron validation for SBGN AF
 		<iso:active pattern="af10112"/>
 		<iso:active pattern="af10113"/>
 		<iso:active pattern="af10114"/>
-	</iso:phase>
-
-	<iso:phase id="layout">
 		<iso:active pattern="af10115"/>
 	</iso:phase>
+
+
 
 	<iso:pattern id="00000">
 		<iso:rule context="/*">
@@ -289,11 +288,12 @@ Schematron validation for SBGN AF
 				@class = 'delay')
 				and @class != 'unit of information'
 				and (
-						(@x <= current()/@x + current()/@width)
-					and (@x + @width >= current()/@x)
-					and (@y <= current()/@y + current()/@height)
-					and (@y + @height >= current()/@y)
+  						(number(sbgn:bbox/@x) &lt;= number(current()/sbgn:bbox/@x) + number(current()/sbgn:bbox/@w)) and
+ 					(number(sbgn:bbox/@x) + number(sbgn:bbox/@w) >= number(current()/sbgn:bbox/@x)) and
+  					(number(sbgn:bbox/@y) &lt;= number(current()/sbgn:bbox/@y) + number(current()/sbgn:bbox/@h)) and
+  					(number(sbgn:bbox/@y) + number(sbgn:bbox/@h) >= number(current()/sbgn:bbox/@y))
 					)
+
 				]
 				)"
 				diagnostics="id">Illegal overlapping nodes are not allowed in SBGN AF.

--- a/validation/rules/sbgn_af.sch
+++ b/validation/rules/sbgn_af.sch
@@ -276,7 +276,7 @@ Schematron validation for SBGN AF
 				id="af10115"
 				name="check-overlapping-nodes"
 				role="error"
-				test="not(following::sbgn:glyph[
+				test="not(following-sibling::sbgn:glyph[
 					(@class= 'biological activity' or
 				@class = 'phenotype' or
 				@class = 'submap' or
@@ -284,7 +284,6 @@ Schematron validation for SBGN AF
 				@class = 'or' or
 				@class = 'not' or
 				@class = 'delay')
-				and @class != 'unit of information'
 				and (
   						(number(sbgn:bbox/@x) &lt;= number(current()/sbgn:bbox/@x) + number(current()/sbgn:bbox/@w)) and
  					(number(sbgn:bbox/@x) + number(sbgn:bbox/@w) >= number(current()/sbgn:bbox/@x)) and

--- a/validation/rules/sbgn_af.sch
+++ b/validation/rules/sbgn_af.sch
@@ -35,8 +35,6 @@ Schematron validation for SBGN AF
 		<iso:active pattern="af10115"/>
 	</iso:phase>
 
-
-
 	<iso:pattern id="00000">
 		<iso:rule context="/*">
 			<iso:assert id="00000" name="sanity-check" test="false()">This assertion should always fail.</iso:assert>
@@ -97,7 +95,7 @@ Schematron validation for SBGN AF
 				id="af10102"
 				name="check-positive-influence-target-class"
 				role="error"
-				see="sbgn-af-L1V1.2-4.2.1.1"				
+				see="sbgn-af-L1V1.0-3.3.1"				
 				test="
 				$target-class='biological activity' or 
 				$target-class='phenotype'" 

--- a/validation/validate.py
+++ b/validation/validate.py
@@ -1,0 +1,124 @@
+import subprocess
+from pathlib import Path
+
+# --------------------
+# Global configuration
+# --------------------
+
+SAXON_JAR = Path("lib/saxon9he.jar")
+SCHEMATRON_DIR = Path("schematron")
+RULES_DIR = Path("rules")
+TESTS_DIR = Path("error-test-files")
+SVRL_ROOT = Path("svrl")
+
+
+# --------------------
+# Utility
+# --------------------
+
+def run(cmd):
+    print("▶", " ".join(cmd))
+    subprocess.run(cmd, check=True)
+
+
+# --------------------
+# Compile step
+# --------------------
+
+def compile_schematron(language: str):
+    """
+    Compile Schematron rules for a given SBGN language (pd / er / af)
+    into an XSLT validator.
+    """
+    language = language.lower()
+
+    sch_file = RULES_DIR / f"sbgn_{language}.sch"
+    step1 = Path(f"sbgn_{language}.step1.sch")
+    step2 = Path(f"sbgn_{language}.step2.sch")
+    validator = Path(f"sbgn_{language}_validator.xsl")
+
+    print(f"\n=== Compiling Schematron for {language.upper()} ===")
+
+    # Step 1: expand includes
+    run([
+        "java", "-jar", str(SAXON_JAR),
+        "-s:" + str(sch_file),
+        "-xsl:" + str(SCHEMATRON_DIR / "iso_dsdl_include.xsl"),
+        "-o:" + str(step1)
+    ])
+
+    # Step 2: expand abstract patterns
+    run([
+        "java", "-jar", str(SAXON_JAR),
+        "-s:" + str(step1),
+        "-xsl:" + str(SCHEMATRON_DIR / "iso_abstract_expand.xsl"),
+        "-o:" + str(step2)
+    ])
+
+    # Step 3: compile to SVRL-producing XSLT
+    run([
+        "java", "-jar", str(SAXON_JAR),
+        "-s:" + str(step2),
+        "-xsl:" + str(SCHEMATRON_DIR / "iso_svrl_for_xslt1.xsl"),
+        "-o:" + str(validator)
+    ])
+
+    print(f" Validator created: {validator}")
+    return validator
+
+
+# --------------------
+# Validation step
+# --------------------
+
+def validate_sbgn(language: str, sbgn_file: Path):
+    """
+    Validate a single SBGN file and write SVRL output.
+    """
+    language = language.upper()
+
+    validator = Path(f"sbgn_{language.lower()}_validator.xsl")
+    svrl_dir = SVRL_ROOT / language
+    svrl_dir.mkdir(parents=True, exist_ok=True)
+
+    output = svrl_dir / (sbgn_file.stem + ".svrl")
+
+    print(f"\n=== Validating {sbgn_file.name} ({language}) ===")
+
+    run([
+        "java", "-jar", str(SAXON_JAR),
+        "-s:" + str(sbgn_file),
+        "-xsl:" + str(validator),
+        "-o:" + str(output)
+    ])
+
+    print(f"SVRL written to {output}")
+
+
+# --------------------
+# Batch validation
+# --------------------
+
+def validate_all(language: str):
+    """
+    Validate all test files for a given language.
+    """
+    language = language.upper()
+    test_dir = TESTS_DIR / language
+
+    for sbgn in sorted(test_dir.glob("*.sbgn")):
+        validate_sbgn(language, sbgn)
+
+
+# --------------------
+# Entry point
+# --------------------
+
+if __name__ == "__main__":
+
+    pd = "pd"
+    af = "af"
+    er = "er"
+    #compile_schematron(pd)
+    compile_schematron(af)
+    validate_all(af)


### PR DESCRIPTION
## Summary

This PR implements a missing layout validation rule from the **SBGN Activity Flow Level 1 Version 1.2 specification** in the `sbgn_af.sch` Schematron rules.

### New rule added

**af10115: Prohibit overlapping Activity Flow nodes**

---

## Detailed Changes

### Rule: No Overlapping Activity Nodes (af10115)

**Spec Reference:** SBGN Activity Flow Level 1 Version 1.2 — Layout constraints

> *Illegal overlapping nodes are not allowed in SBGN Activity Flow diagrams.*

---

### Implementation

The rule checks that Activity Flow node glyphs do not spatially overlap.

The following glyph classes are validated:

* biological activity
* phenotype
* submap
* and
* or
* not
* delay

For each glyph, the rule:

1. Retrieves its bounding box (`sbgn:bbox`)
2. Compares it with subsequent AF glyph bounding boxes
3. Uses axis-aligned rectangle intersection logic
4. Reports an error if any overlap (including edge-touching) is detected

The `following::` axis is used to avoid symmetric duplicate checks and improve evaluation efficiency.

---

### Example Violation

```xml
<glyph id="glyph1" class="biological activity">
    <bbox x="26" y="30" w="108" h="60"/>
</glyph>

<glyph id="glyph2" class="biological activity">
    <bbox x="26" y="30" w="108" h="60"/> <!-- ERROR -->
</glyph>
```

This results in:

```
af10115: Illegal overlapping nodes are not allowed in SBGN AF.
```

---

## Verification

Validation was performed using the Schematron compilation and validation commands described in the libSBGN repository README.

To streamline testing, these commands were wrapped in a small helper script (`validate.py`) that automates:

* Schematron compilation (include expansion, abstract pattern expansion, SVRL stylesheet generation)
* Batch validation of SBGN test files
* SVRL report generation

### Test Cases

* **Overlapping biological activity glyphs**

  * Correctly triggered af10115
  * Diagnostic reported the failing glyph ID

* **Non-overlapping glyphs**

  * Passed validation

All existing AF validation tests passed successfully.

---

## Notes

* The rule relies on `sbgn:bbox` geometry, consistent with SBGN-ML layout encoding.
* Diagnostics currently report only the failing glyph ID.
* If preferred, diagnostics can be extended to report conflicting glyph IDs in a follow-up change.

---

## Impact

This PR improves Activity Flow layout validation by enforcing a specification constraint that was previously not checked, helping detect diagram layout errors early in the validation pipeline.